### PR TITLE
Python 3.10 compatibility

### DIFF
--- a/src/main/c/jpy_jobj.c
+++ b/src/main/c/jpy_jobj.c
@@ -701,7 +701,7 @@ int JType_InitSlots(JPy_JType* type)
 
     typeObj = (PyTypeObject*) type;
 
-    Py_REFCNT(typeObj) = 1;
+    Py_SET_REFCNT(typeObj, 1);
     Py_TYPE(typeObj) = NULL;
     Py_SIZE(typeObj) = 0;
     // todo: The following lines are actually correct, but setting Py_TYPE(type) = &JType_Type results in an interpreter crash. Why?


### PR DESCRIPTION
Py_REFCNT() is no longer an lvalue, call Py_SET_REFCNT() instead.

Debian Bug: https://bugs.debian.org/999409