### PR TITLE
Guard Py_SET_REFCNT to Python 3.9+

### DIFF
--- a/src/main/c/jpy_compat.h
+++ b/src/main/c/jpy_compat.h
@@ -33,6 +33,9 @@ extern "C" {
 #if PY_MINOR_VERSION >= 5
 #define JPY_COMPAT_35P 1
 #endif
+#if PY_MINOR_VERSION >= 9
+#define JPY_COMPAT_39P 1
+#endif
 #undef JPY_COMPAT_27
 #else
 #error JPY_VERSION_ERROR

--- a/src/main/c/jpy_jobj.c
+++ b/src/main/c/jpy_jobj.c
@@ -713,7 +713,11 @@ int JType_InitSlots(JPy_JType* type)
 
     typeObj = JTYPE_AS_PYTYPE(type);
 
-    Py_SET_REFCNT(typeObj, 1);
+    #if defined(JPY_COMPAT_39P)
+        Py_SET_REFCNT(typeObj, 1);
+    #else
+        Py_REFCNT(typeObj) = 1;
+    #endif
     Py_TYPE(typeObj) = NULL;
     Py_SIZE(typeObj) = 0;
     // todo: The following lines are actually correct, but setting Py_TYPE(type) = &JType_Type results in an interpreter crash. Why?


### PR DESCRIPTION
Follow up to https://github.com/jpy-consortium/jpy/pull/14