### PR TITLE
Add Java process lookup for 'java.home' in find_jvm_dll_file()

### DIFF
--- a/jpyutil.py
+++ b/jpyutil.py
@@ -160,6 +160,16 @@ def find_jdk_home_dir():
 
     return None
 
+def _java_process_java_home():
+    logger.debug('Checking Java for JAVA_HOME...')
+    try:
+        from java_utilities import lookup_property
+        return lookup_property('java.home', use_env=False)
+    except ImportError:
+        logger.debug("java_utilities not found, skipping java process check")
+    except Exception as e:
+        logger.debug(e, exc_info=True)
+    return None
 
 def find_jvm_dll_file(java_home_dir=None, fail=False):
     """
@@ -187,6 +197,12 @@ def find_jvm_dll_file(java_home_dir=None, fail=False):
             jvm_dll_path = _find_jvm_dll_file(java_home_dir)
             if jvm_dll_path:
                 return jvm_dll_path
+
+    java_home_dir = _java_process_java_home()
+    if java_home_dir:
+        jvm_dll_path = _find_jvm_dll_file(java_home_dir)
+        if jvm_dll_path:
+            return jvm_dll_path
 
     jvm_dll_path = ctypes.util.find_library(JVM_LIB_NAME)
     if jvm_dll_path:


### PR DESCRIPTION
This adds an optional check when the `java-utilities` [package](https://pypi.org/project/java-utilities/) is installed.

When java-utilities is not installed, it behaves as it does today:
```
Python 3.10.7 (main, Sep  7 2022, 00:00:00) [GCC 12.2.1 20220819 (Red Hat 12.2.1-1)] on linux                                                                                    
Type "help", "copyright", "credits" or "license" for more information.                                                                                                           
>>> import jpyutil                                                                                                                                                               
>>> jpyutil.init_jvm()                                                                                                                                                           
jpyutil - WARNING: Failed to preload JVM shared library. No shared library found.                                                                                                
Traceback (most recent call last):                                                                                                                                               
  File "<stdin>", line 1, in <module>                                                                                                                                            
  File "/home/devin/dev/jpy/jpyutil.py", line 455, in init_jvm                                                                                                                   
    import jpy                                                                                                                                                                   
ImportError: libjvm.so: cannot open shared object file: No such file or directory                                                                                                
>>>
```

When it is installed, it uses the java.home found from the `java` found on the path:
```
Python 3.10.7 (main, Sep  7 2022, 00:00:00) [GCC 12.2.1 20220819 (Red Hat 12.2.1-1)] on linux                                                                                    
Type "help", "copyright", "credits" or "license" for more information.                                                                                                           
>>> import jpyutil                                                                                                                                                               
>>> jpyutil.init_jvm()                                                                                                                                                           
(<CDLL '/usr/lib/jvm/java-17-openjdk-17.0.4.1.1-1.fc36.x86_64/lib/server/libjvm.so', handle 55a7d4beb1d0 at 0x7f14d714fbb0>, ['-Djpy.jpyLib=/tmp/jpy/lib64/python3.10/site-packag
es/jpy.cpython-310-x86_64-linux-gnu.so', '-Djpy.jdlLib=/tmp/jpy/lib64/python3.10/site-packages/jdl.cpython-310-x86_64-linux-gnu.so', '-Djpy.pythonLib=/usr/lib64/libpython3.10.so
', '-Djpy.pythonPrefix=/tmp/jpy', '-Djpy.pythonExecutable=/tmp/jpy/bin/python'])                                                                                                 
>>>
```

Fixes https://github.com/jpy-consortium/jpy/issues/82
