### PR TITLE
Python 3.11 compatibility

### DIFF
--- a/.github/env/Linux/requirements.txt
+++ b/.github/env/Linux/requirements.txt
@@ -1,2 +1,3 @@
 wheel
 auditwheel
+patchelf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,23 @@ jobs:
       fail-fast: false
       matrix:
         info:
+          - { machine: 'ubuntu-20.04', python: '3.6',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
+          - { machine: 'ubuntu-20.04', python: '3.7',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
+          - { machine: 'ubuntu-20.04', python: '3.8',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
+          - { machine: 'ubuntu-20.04', python: '3.9',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
+          - { machine: 'ubuntu-20.04', python: '3.10', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
           - { machine: 'ubuntu-20.04', python: '3.11', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
+          - { machine: 'windows-2022', python: '3.6',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
+          - { machine: 'windows-2022', python: '3.7',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
+          - { machine: 'windows-2022', python: '3.8',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
+          - { machine: 'windows-2022', python: '3.9',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
+          - { machine: 'windows-2022', python: '3.10', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
           - { machine: 'windows-2022', python: '3.11', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
+          - { machine: 'macos-11', python: '3.6', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
+          - { machine: 'macos-11', python: '3.7', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
+          - { machine: 'macos-11', python: '3.8', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
+          - { machine: 'macos-11', python: '3.9', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
+          - { machine: 'macos-11', python: '3.10', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
           - { machine: 'macos-11', python: '3.11', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         info:
-          - { machine: 'ubuntu-20.04', python: '3.11', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
+          - { machine: 'ubuntu-22.04', python: '3.11', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
           - { machine: 'windows-2022', python: '3.11', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
           - { machine: 'macos-11', python: '3.11', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         info:
-          - { machine: 'ubuntu-22.04', python: '3.11', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
+          - { machine: 'ubuntu-20.04', python: '3.11', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
           - { machine: 'windows-2022', python: '3.11', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
           - { machine: 'macos-11', python: '3.11', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,21 +44,9 @@ jobs:
       fail-fast: false
       matrix:
         info:
-          - { machine: 'ubuntu-20.04', python: '3.6',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
-          - { machine: 'ubuntu-20.04', python: '3.7',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
-          - { machine: 'ubuntu-20.04', python: '3.8',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
-          - { machine: 'ubuntu-20.04', python: '3.9',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
-          - { machine: 'ubuntu-20.04', python: '3.10', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
-          - { machine: 'windows-2022', python: '3.6',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
-          - { machine: 'windows-2022', python: '3.7',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
-          - { machine: 'windows-2022', python: '3.8',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
-          - { machine: 'windows-2022', python: '3.9',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
-          - { machine: 'windows-2022', python: '3.10', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
-          - { machine: 'macos-11', python: '3.6', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
-          - { machine: 'macos-11', python: '3.7', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
-          - { machine: 'macos-11', python: '3.8', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
-          - { machine: 'macos-11', python: '3.9', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
-          - { machine: 'macos-11', python: '3.10', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
+          - { machine: 'ubuntu-20.04', python: '3.11', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
+          - { machine: 'windows-2022', python: '3.11', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
+          - { machine: 'macos-11', python: '3.11', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
 
     steps:
       - uses: actions/checkout@v3

--- a/src/main/c/jni/org_jpy_PyLib.c
+++ b/src/main/c/jni/org_jpy_PyLib.c
@@ -2485,13 +2485,12 @@ void PyLib_HandlePythonException(JNIEnv* jenv)
         pyTraceback = pyTraceback->tb_next;
 
     if (pyTraceback != NULL) {
-        PyObject* pyFrame = NULL;
-        PyObject* pyCode = NULL;
+        PyFrameObject* pyFrame = NULL;
+        PyCodeObject* pyCode = NULL;
         linenoChars = PyLib_ObjToChars(PyObject_GetAttrString(pyTraceback, "tb_lineno"), &pyLinenoUtf8);
-        // todo: come back to this
         pyFrame = PyObject_GetAttrString(pyTraceback, "tb_frame");
         if (pyFrame != NULL) {
-            pyCode = PyObject_GetAttrString(pyFrame, "f_code");
+            pyCode = PyFrame_GetCode(pyFrame);
             if (pyCode != NULL) {
                 filenameChars = PyLib_ObjToChars(PyObject_GetAttrString(pyCode, "co_filename"), &pyFilenameUtf8);
                 namespaceChars = PyLib_ObjToChars(PyObject_GetAttrString(pyCode, "co_name"), &pyNamespaceUtf8);

--- a/src/main/c/jni/org_jpy_PyLib.c
+++ b/src/main/c/jni/org_jpy_PyLib.c
@@ -2488,6 +2488,7 @@ void PyLib_HandlePythonException(JNIEnv* jenv)
         PyObject* pyFrame = NULL;
         PyObject* pyCode = NULL;
         linenoChars = PyLib_ObjToChars(PyObject_GetAttrString(pyTraceback, "tb_lineno"), &pyLinenoUtf8);
+        // todo: come back to this
         pyFrame = PyObject_GetAttrString(pyTraceback, "tb_frame");
         if (pyFrame != NULL) {
             pyCode = PyObject_GetAttrString(pyFrame, "f_code");
@@ -2739,31 +2740,37 @@ static int format_python_traceback(PyTracebackObject *tb, char **buf, int *bufLe
         tb = tb->tb_next;
     }
     while (tb != NULL && err == 0) {
+        PyCodeObject* co = PyFrame_GetCode(tb->tb_frame);
         if (last_file == NULL ||
-            tb->tb_frame->f_code->co_filename != last_file ||
+            co->co_filename != last_file ||
             last_line == -1 || tb->tb_lineno != last_line ||
-            last_name == NULL || tb->tb_frame->f_code->co_name != last_name) {
+            last_name == NULL || co->co_name != last_name) {
             if (cnt >  PYLIB_RECURSIVE_CUTOFF) {
                 pyObjUtf8 = format_line_repeated(cnt);
                 err = append_to_java_message(pyObjUtf8, buf, bufLen);
-                if (err != 0) 
-                        return err;
+                if (err != 0) {
+                    JPy_DECREF(co);
+                    return err;
+                }
             }
-            last_file = tb->tb_frame->f_code->co_filename;
+            last_file = co->co_filename;
             last_line = tb->tb_lineno;
-            last_name = tb->tb_frame->f_code->co_name;
+            last_name = co->co_name;
             cnt = 0;
         }
         cnt++;
         if (err == 0 && cnt <= PYLIB_RECURSIVE_CUTOFF) {
             pyObjUtf8 = format_displayline( 
-                                 tb->tb_frame->f_code->co_filename,
+                                 co->co_filename,
                                  tb->tb_lineno,
-                                 tb->tb_frame->f_code->co_name);
+                                 co->co_name);
             err = append_to_java_message(pyObjUtf8, buf, bufLen);
-            if (err != 0) 
+            if (err != 0) {
+                JPy_DECREF(co);
                 return err;
+            }
         }
+        JPy_DECREF(co);
         tb = tb->tb_next;
     }
     if (err == 0 && cnt > PYLIB_RECURSIVE_CUTOFF) {

--- a/src/main/c/jpy_compat.h
+++ b/src/main/c/jpy_compat.h
@@ -22,6 +22,7 @@ extern "C" {
 #endif
 
 #include <Python.h>
+#include "frameobject.h"
 
 #define JPY_VERSION_ERROR "jpy requires either Python 2.7 or Python 3.3+"
 

--- a/src/main/c/jpy_compat.h
+++ b/src/main/c/jpy_compat.h
@@ -88,6 +88,13 @@ static inline void _Py_SET_TYPE(PyObject *ob, PyTypeObject *type)
 #define Py_SET_TYPE(ob, type) _Py_SET_TYPE((PyObject*)(ob), type)
 #endif
 
+// As recommended by https://docs.python.org/3.11/whatsnew/3.11.html#whatsnew311-c-api-porting
+#if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_SIZE)
+static inline void _Py_SET_SIZE(PyVarObject *ob, Py_ssize_t size)
+{ ob->ob_size = size; }
+#define Py_SET_SIZE(ob, size) _Py_SET_SIZE((PyVarObject*)(ob), size)
+#endif
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/src/main/c/jpy_compat.h
+++ b/src/main/c/jpy_compat.h
@@ -81,6 +81,12 @@ wchar_t* JPy_AsWideCharString_PriorToPy33(PyObject *unicode, Py_ssize_t *size);
 
 #endif
 
+// As recommended by https://docs.python.org/3.11/whatsnew/3.11.html#whatsnew311-c-api-porting
+#if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_TYPE)
+static inline void _Py_SET_TYPE(PyObject *ob, PyTypeObject *type)
+{ ob->ob_type = type; }
+#define Py_SET_TYPE(ob, type) _Py_SET_TYPE((PyObject*)(ob), type)
+#endif
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/main/c/jpy_compat.h
+++ b/src/main/c/jpy_compat.h
@@ -95,6 +95,15 @@ static inline void _Py_SET_SIZE(PyVarObject *ob, Py_ssize_t size)
 #define Py_SET_SIZE(ob, size) _Py_SET_SIZE((PyVarObject*)(ob), size)
 #endif
 
+// As recommended by https://docs.python.org/3.11/whatsnew/3.11.html#pyframeobject-3-11-hiding
+#if PY_VERSION_HEX < 0x030900B1
+static inline PyCodeObject* PyFrame_GetCode(PyFrameObject *frame)
+{
+    Py_INCREF(frame->f_code);
+    return frame->f_code;
+}
+#endif
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/src/main/c/jpy_jobj.c
+++ b/src/main/c/jpy_jobj.c
@@ -718,13 +718,13 @@ int JType_InitSlots(JPy_JType* type)
     #else
         Py_REFCNT(typeObj) = 1;
     #endif
-    Py_TYPE(typeObj) = NULL;
+    Py_SET_TYPE(typeObj, NULL);
     Py_SIZE(typeObj) = 0;
     // todo: The following lines are actually correct, but setting Py_TYPE(type) = &JType_Type results in an interpreter crash. Why?
     // This is still a problem because all the JType slots are actually never called (especially JType_getattro is
     // needed to resolve unresolved JTypes and to recognize static field and methods access)
     //JPy_INCREF(&JType_Type);
-    //Py_TYPE(type) = &JType_Type;
+    //Py_SET_TYPE(type, &JType_Type);
     //Py_SIZE(type) = sizeof (JPy_JType);
 
     typeObj->tp_basicsize = isPrimitiveArray ? sizeof (JPy_JArray) : sizeof (JPy_JObj);

--- a/src/main/c/jpy_jobj.c
+++ b/src/main/c/jpy_jobj.c
@@ -719,13 +719,13 @@ int JType_InitSlots(JPy_JType* type)
         Py_REFCNT(typeObj) = 1;
     #endif
     Py_SET_TYPE(typeObj, NULL);
-    Py_SIZE(typeObj) = 0;
+    Py_SET_SIZE(typeObj, 0);
     // todo: The following lines are actually correct, but setting Py_TYPE(type) = &JType_Type results in an interpreter crash. Why?
     // This is still a problem because all the JType slots are actually never called (especially JType_getattro is
     // needed to resolve unresolved JTypes and to recognize static field and methods access)
     //JPy_INCREF(&JType_Type);
     //Py_SET_TYPE(type, &JType_Type);
-    //Py_SIZE(type) = sizeof (JPy_JType);
+    //Py_SET_SIZE(type, sizeof (JPy_JType));
 
     typeObj->tp_basicsize = isPrimitiveArray ? sizeof (JPy_JArray) : sizeof (JPy_JObj);
     typeObj->tp_itemsize = 0;


### PR DESCRIPTION
See https://docs.python.org/3.11/whatsnew/3.11.html#whatsnew311-c-api-porting

Added Py_SET_TYPE compatibility
Added Py_SET_SIZE compatibility
Added PyFrame_GetCode compatibility
Added explicit patchelf dependency instead of relying on system binary, not included by default (see https://github.com/pypa/auditwheel/issues/386, https://github.com/pypa/auditwheel/pull/403)
Added Python 3.11 CI logic

Fixes #95 