### PR TITLE
Fix Mac OSX + OpenJDK builds where `JAVA_HOME` contains `libexec` but not `lib`

### DIFF
--- a/.github/env/Linux/requirements.txt
+++ b/.github/env/Linux/requirements.txt
@@ -1,3 +1,4 @@
+setuptools
 wheel
 auditwheel
 patchelf

--- a/.github/env/Windows/requirements.txt
+++ b/.github/env/Windows/requirements.txt
@@ -1,1 +1,2 @@
+setuptools
 wheel

--- a/.github/env/macOS/requirements.txt
+++ b/.github/env/macOS/requirements.txt
@@ -1,1 +1,2 @@
+setuptools
 wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,18 +50,21 @@ jobs:
           - { machine: 'ubuntu-20.04', python: '3.9',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
           - { machine: 'ubuntu-20.04', python: '3.10', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
           - { machine: 'ubuntu-20.04', python: '3.11', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
+          - { machine: 'ubuntu-20.04', python: '3.12', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
           - { machine: 'windows-2022', python: '3.6',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
           - { machine: 'windows-2022', python: '3.7',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
           - { machine: 'windows-2022', python: '3.8',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
           - { machine: 'windows-2022', python: '3.9',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
           - { machine: 'windows-2022', python: '3.10', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
           - { machine: 'windows-2022', python: '3.11', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
+          - { machine: 'windows-2022', python: '3.12', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
           - { machine: 'macos-11', python: '3.6', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
           - { machine: 'macos-11', python: '3.7', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
           - { machine: 'macos-11', python: '3.8', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
           - { machine: 'macos-11', python: '3.9', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
           - { machine: 'macos-11', python: '3.10', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
           - { machine: 'macos-11', python: '3.11', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
+          - { machine: 'macos-11', python: '3.12', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
           # Add M1 powered runners when available
           # https://github.com/jpy-consortium/jpy/issues/110
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Install a JDK 8, preferably the Oracle distribution. Set `JDK_HOME` or
 
     $ export JDK_HOME=<your-jdk-dir>
     $ export JAVA_HOME=$JDK_HOME
+    $ pip install setuptools wheel
     $ python setup.py build maven bdist_wheel
 
 On success, the wheel is found in the `dist` directory.
@@ -68,12 +69,14 @@ SDK 7.1::
     > SET DISTUTILS_USE_SDK=1
     > C:\Program Files\Microsoft SDKs\Windows\v7.1\bin\setenv /x64 /release
     > SET JDK_HOME=<your-jdk-dir>
+    > pip install setuptools wheel
     > python setup.py build maven bdist_wheel
     
 With Visual Studio 14 and higher it is much easier::
 
     > SET VS100COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\
     > SET JDK_HOME=<your-jdk-dir>
+    > pip install setuptools wheel
     > python setup.py build maven bdist_wheel
 
 On success, the wheel can be found in the `dist` directory.

--- a/jpyutil.py
+++ b/jpyutil.py
@@ -148,11 +148,10 @@ def find_jdk_home_dir():
         
         for root, dir_names, file_names in os.walk(path):
             for d in dir_names:
-                p = os.path.join(path, d)
-                rst = walk_to_jdk(p)
+                p = os.path.join(root, d)
 
-                if rst:
-                    return rst
+                if p and is_jdk_dir(p):
+                    return p
             
         return None
 

--- a/jpyutil.py
+++ b/jpyutil.py
@@ -138,9 +138,8 @@ def find_jdk_home_dir():
     """
     for name in JDK_HOME_VARS:
         jdk_home_dir = os.environ.get(name, None)
-        if jdk_home_dir \
-                and os.path.exists(os.path.join(jdk_home_dir, 'include')) \
-                and (os.path.exists(os.path.join(jdk_home_dir, 'lib')) or os.path.exists(os.path.join(jdk_home_dir, 'libexec'))):
+        if jdk_home_dir:
+            logger.debug(f'JAVA_HOME set by environment variable to {jdk_home_dir}')
             return jdk_home_dir
     logger.debug('Checking Maven for JAVA_HOME...')
     try:
@@ -152,7 +151,9 @@ def find_jdk_home_dir():
             if part.startswith('Java home:'):
                 path = part.split(':')[1].strip()
                 if path.endswith('jre'):
-                    return path[0:-3]
+                    java_home = path[0:-3]
+                    logger.debug(f'JAVA_HOME set by maven to {java_home}')
+                    return java_home
                 
     except Exception:
         # maven probably isn't installed or not on PATH

--- a/jpyutil.py
+++ b/jpyutil.py
@@ -140,7 +140,7 @@ def find_jdk_home_dir():
         jdk_home_dir = os.environ.get(name, None)
         if jdk_home_dir \
                 and os.path.exists(os.path.join(jdk_home_dir, 'include')) \
-                and (os.path.exists(os.path.join(jdk_home_dir, 'lib') or os.path.exists(os.path.join(jdk_home_dir, 'libexec'))):
+                and (os.path.exists(os.path.join(jdk_home_dir, 'lib')) or os.path.exists(os.path.join(jdk_home_dir, 'libexec'))):
             return jdk_home_dir
     logger.debug('Checking Maven for JAVA_HOME...')
     try:

--- a/jpyutil.py
+++ b/jpyutil.py
@@ -160,13 +160,19 @@ def find_jdk_home_dir():
         jdk_home_dir = os.environ.get(name, None)
         if jdk_home_dir:
             logger.debug(f'JAVA_HOME set by environment variable to {jdk_home_dir}')
+
+            if is_jdk_dir(jdk_home_dir):
+                return jdk_home_dir
+
             jdk_dir = walk_to_jdk(jdk_home_dir)
 
             if jdk_dir:
-                return jdk_dir
+                logger.error(f'JAVA_HOME set by environment variable to {jdk_home_dir} but no no "include" or "lib" directory found.  Possibly you meant {jdk_dir}?')
             else:
-                logger.debug(f'JAVA_HOME set by environment variable to {jdk_home_dir} but no JDK found.')
-                
+                logger.error(f'JAVA_HOME set by environment variable to {jdk_home_dir} but no no "include" or "lib" directory found.  Does not appear to be a JDK directory.')
+
+            exit(1)
+
     logger.debug('Checking Maven for JAVA_HOME...')
     try:
         output = subprocess.check_output(['mvn', '-v'])

--- a/jpyutil.py
+++ b/jpyutil.py
@@ -140,7 +140,7 @@ def find_jdk_home_dir():
         jdk_home_dir = os.environ.get(name, None)
         if jdk_home_dir \
                 and os.path.exists(os.path.join(jdk_home_dir, 'include')) \
-                and os.path.exists(os.path.join(jdk_home_dir, 'lib')):
+                and (os.path.exists(os.path.join(jdk_home_dir, 'lib') or os.path.exists(os.path.join(jdk_home_dir, 'libexec'))):
             return jdk_home_dir
     logger.debug('Checking Maven for JAVA_HOME...')
     try:


### PR DESCRIPTION
Fix Mac OSX + OpenJDK builds where `JAVA_HOME` contains `libexec` but not `lib`.
Build for Python 3.12

Resolves #118 
