### PR TITLE
Python 3.12 build

### DIFF
--- a/.github/docker/docker-bake.hcl
+++ b/.github/docker/docker-bake.hcl
@@ -5,7 +5,8 @@ group "default" {
         "python-38-linux",
         "python-39-linux",
         "python-310-linux",
-        "python-311-linux"
+        "python-311-linux",
+        "python-312-linux"
     ]
 }
 
@@ -66,5 +67,12 @@ target "python-311-linux" {
     inherits = [ "shared" ]
     args = {
         PYTHON_TAG = "3.11-${DEBIAN_BASE}"
+    }
+}
+
+target "python-312-linux" {
+    inherits = [ "shared" ]
+    args = {
+        PYTHON_TAG = "3.12-${DEBIAN_BASE}"
     }
 }

--- a/.github/env/Linux/requirements.txt
+++ b/.github/env/Linux/requirements.txt
@@ -1,3 +1,4 @@
+setuptools
 wheel
 auditwheel
 patchelf

--- a/.github/env/Windows/requirements.txt
+++ b/.github/env/Windows/requirements.txt
@@ -1,1 +1,2 @@
+setuptools
 wheel

--- a/.github/env/macOS/requirements.txt
+++ b/.github/env/macOS/requirements.txt
@@ -1,1 +1,2 @@
+setuptools
 wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,18 +50,21 @@ jobs:
           - { machine: 'ubuntu-20.04', python: '3.9',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
           - { machine: 'ubuntu-20.04', python: '3.10', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
           - { machine: 'ubuntu-20.04', python: '3.11', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
+          - { machine: 'ubuntu-20.04', python: '3.12', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/Linux/bdist-wheel.sh' }
           - { machine: 'windows-2022', python: '3.6',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
           - { machine: 'windows-2022', python: '3.7',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
           - { machine: 'windows-2022', python: '3.8',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
           - { machine: 'windows-2022', python: '3.9',  pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
           - { machine: 'windows-2022', python: '3.10', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
           - { machine: 'windows-2022', python: '3.11', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
+          - { machine: 'windows-2022', python: '3.12', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.\.github\env\Windows\bdist-wheel.ps1' }
           - { machine: 'macos-11', python: '3.6', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
           - { machine: 'macos-11', python: '3.7', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
           - { machine: 'macos-11', python: '3.8', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
           - { machine: 'macos-11', python: '3.9', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
           - { machine: 'macos-11', python: '3.10', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
           - { machine: 'macos-11', python: '3.11', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
+          - { machine: 'macos-11', python: '3.12', pythonArchitecture: 'x64', arch: 'amd64', cmd: '.github/env/macOS/bdist-wheel.sh' }
           # Add M1 powered runners when available
           # https://github.com/jpy-consortium/jpy/issues/110
 


### PR DESCRIPTION
distutils is no longer provided on python 3.12+, see https://peps.python.org/pep-0632/#backwards-compatibility.

Fixes #115