### PR TITLE
Use Py_ssize_t when calculate buffer len

### DIFF
--- a/src/main/c/jni/org_jpy_PyLib.c
+++ b/src/main/c/jni/org_jpy_PyLib.c
@@ -1021,7 +1021,7 @@ jlong JNICALL Java_org_jpy_PyLib_executeCode
     codeChars = (*jenv)->GetStringUTFChars(jenv, jCode, NULL);
     if (codeChars == NULL) {
         PyLib_ThrowOOM(jenv);
-        return NULL;
+        return 0;
     }
 
     JPy_DIAG_PRINT(JPy_DIAG_F_EXEC, "Java_org_jpy_PyLib_executeCode: code='%s'\n", codeChars);

--- a/src/main/c/jpy_diag.c
+++ b/src/main/c/jpy_diag.c
@@ -103,7 +103,7 @@ PyTypeObject Diag_Type =
     sizeof (JPy_Diag),            /* tp_basicsize */
     0,                            /* tp_itemsize */
     NULL,                         /* tp_dealloc */
-    NULL,                         /* tp_print */
+    0,                            /* tp_print */
     NULL,                         /* tp_getattr */
     NULL,                         /* tp_setattr */
     NULL,                         /* tp_reserved */

--- a/src/main/c/jpy_jarray.c
+++ b/src/main/c/jpy_jarray.c
@@ -109,7 +109,7 @@ int JArray_GetBufferProc(JPy_JArray* self, Py_buffer* view, int flags, char java
 
     // Step 2/5
     view->buf = buf;
-    view->len = itemCount * itemSize;
+    view->len = (Py_ssize_t)itemCount * (Py_ssize_t)itemSize;
     view->itemsize = itemSize;
     view->readonly = (flags & (PyBUF_WRITE | PyBUF_WRITEABLE)) == 0;
     self->bufReadonly &= view->readonly;

--- a/src/main/c/jpy_jfield.c
+++ b/src/main/c/jpy_jfield.c
@@ -100,7 +100,7 @@ PyTypeObject JField_Type = {
     sizeof (JPy_JField),          /* tp_basicsize */
     0,                            /* tp_itemsize */
     (destructor)JField_dealloc,   /* tp_dealloc */
-    NULL,                         /* tp_print */
+    0,                            /* tp_print */
     NULL,                         /* tp_getattr */
     NULL,                         /* tp_setattr */
     NULL,                         /* tp_reserved */

--- a/src/main/c/jpy_jmethod.c
+++ b/src/main/c/jpy_jmethod.c
@@ -719,7 +719,7 @@ PyTypeObject JMethod_Type = {
     sizeof (JPy_JMethod),         /* tp_basicsize */
     0,                            /* tp_itemsize */
     (destructor)JMethod_dealloc,  /* tp_dealloc */
-    NULL,                         /* tp_print */
+    0,                            /* tp_print */
     NULL,                         /* tp_getattr */
     NULL,                         /* tp_setattr */
     NULL,                         /* tp_reserved */
@@ -1036,7 +1036,7 @@ PyTypeObject JOverloadedMethod_Type = {
     sizeof (JPy_JOverloadedMethod),         /* tp_basicsize */
     0,                            /* tp_itemsize */
     (destructor)JOverloadedMethod_dealloc,  /* tp_dealloc */
-    NULL,                         /* tp_print */
+    0,                            /* tp_print */
     NULL,                         /* tp_getattr */
     NULL,                         /* tp_setattr */
     NULL,                         /* tp_reserved */

--- a/src/main/c/jpy_jtype.c
+++ b/src/main/c/jpy_jtype.c
@@ -2578,7 +2578,7 @@ PyTypeObject JType_Type = {
     sizeof (JPy_JType),          /* tp_basicsize */
     0,                           /* tp_itemsize */
     (destructor) JType_dealloc,  /* tp_dealloc */
-    NULL,                         /* tp_print */
+    0,                            /* tp_print */
     NULL,                         /* tp_getattr */
     NULL,                         /* tp_setattr */
     NULL,                         /* tp_reserved */

--- a/src/main/c/jpy_verboseexcept.c
+++ b/src/main/c/jpy_verboseexcept.c
@@ -61,7 +61,7 @@ PyTypeObject VerboseExceptions_Type =
     sizeof (VerboseExceptions_Type),            /* tp_basicsize */
     0,                            /* tp_itemsize */
     NULL,                         /* tp_dealloc */
-    NULL,                         /* tp_print */
+    0,                            /* tp_print */
     NULL,                         /* tp_getattr */
     NULL,                         /* tp_setattr */
     NULL,                         /* tp_reserved */


### PR DESCRIPTION
Also fixed all the pointer to long conversions that clang 15 considers error by default on MacOS M2

Fixes #143

