### PR TITLE
Delay resolving super classes until referenced 

### DIFF
--- a/src/main/c/jpy_jobj.c
+++ b/src/main/c/jpy_jobj.c
@@ -726,11 +726,13 @@ int JType_InitSlots(JPy_JType* type)
 
     typeObj = JTYPE_AS_PYTYPE(type);
 
-    #if defined(JPY_COMPAT_39P)
-        Py_SET_REFCNT(typeObj, 1);
-    #else
-        Py_REFCNT(typeObj) = 1;
-    #endif
+    // This is hacky to make the caller JType_GetType be able to call JPy_INCREF regardless if the type was already created,
+    // but it will cause a ref counting error when this function fails, and we need to remove the type from the registry
+    //    #if defined(JPY_COMPAT_39P)
+    //        Py_SET_REFCNT(typeObj, 1);
+    //    #else
+    //        Py_REFCNT(typeObj) = 1;
+    //    #endif
     Py_SET_TYPE(typeObj, NULL);
     Py_SET_SIZE(typeObj, 0);
     // todo: The following lines are actually correct, but setting Py_TYPE(type) = &JType_Type results in an interpreter crash. Why?

--- a/src/main/c/jpy_jobj.c
+++ b/src/main/c/jpy_jobj.c
@@ -726,14 +726,6 @@ int JType_InitSlots(JPy_JType* type)
 
     typeObj = JTYPE_AS_PYTYPE(type);
 
-    // This is hacky to make the caller JType_GetType able to call JPy_INCREF regardless if the type was already created,
-    // but it will cause a ref counting error when this function fails, and we need to remove the type from the registry.
-    // The proper ref counting needs to be done in JType_GetType().
-    //    #if defined(JPY_COMPAT_39P)
-    //        Py_SET_REFCNT(typeObj, 1);
-    //    #else
-    //        Py_REFCNT(typeObj) = 1;
-    //    #endif
     Py_SET_TYPE(typeObj, NULL);
     Py_SET_SIZE(typeObj, 0);
     // todo: The following lines are actually correct, but setting Py_TYPE(type) = &JType_Type results in an interpreter crash. Why?

--- a/src/main/c/jpy_jobj.c
+++ b/src/main/c/jpy_jobj.c
@@ -726,7 +726,7 @@ int JType_InitSlots(JPy_JType* type)
 
     typeObj = JTYPE_AS_PYTYPE(type);
 
-    // This is hacky to make the caller JType_GetType be able to call JPy_INCREF regardless if the type was already created,
+    // This is hacky to make the caller JType_GetType able to call JPy_INCREF regardless if the type was already created,
     // but it will cause a ref counting error when this function fails, and we need to remove the type from the registry
     //    #if defined(JPY_COMPAT_39P)
     //        Py_SET_REFCNT(typeObj, 1);

--- a/src/main/c/jpy_jobj.c
+++ b/src/main/c/jpy_jobj.c
@@ -727,7 +727,8 @@ int JType_InitSlots(JPy_JType* type)
     typeObj = JTYPE_AS_PYTYPE(type);
 
     // This is hacky to make the caller JType_GetType able to call JPy_INCREF regardless if the type was already created,
-    // but it will cause a ref counting error when this function fails, and we need to remove the type from the registry
+    // but it will cause a ref counting error when this function fails, and we need to remove the type from the registry.
+    // The proper ref counting needs to be done in JType_GetType().
     //    #if defined(JPY_COMPAT_39P)
     //        Py_SET_REFCNT(typeObj, 1);
     //    #else

--- a/src/main/c/jpy_jtype.c
+++ b/src/main/c/jpy_jtype.c
@@ -171,7 +171,7 @@ JPy_JType* JType_GetType(JNIEnv* jenv, jclass classRef, jboolean resolve)
         //printf("T2: type->tp_init=%p\n", ((PyTypeObject*)type)->tp_init);
 
         // ... before we can continue processing the super type ...
-        if (JType_InitSuperType(jenv, type, resolve) < 0) {
+        if (JType_InitSuperType(jenv, type, JNI_FALSE) < 0) {
             PyDict_DelItem(JPy_Types, typeKey);
             return NULL;
         }

--- a/src/main/c/jpy_jtype.c
+++ b/src/main/c/jpy_jtype.c
@@ -179,7 +179,7 @@ JPy_JType* JType_GetType(JNIEnv* jenv, jclass classRef, jboolean resolve)
         //printf("T3: type->tp_init=%p\n", ((PyTypeObject*)type)->tp_init);
 
         // ... and processing the component type.
-        if (JType_InitComponentType(jenv, type, resolve) < 0) {
+        if (JType_InitComponentType(jenv, type, JNI_FALSE) < 0) {
             PyDict_DelItem(JPy_Types, typeKey);
             return NULL;
         }
@@ -194,6 +194,7 @@ JPy_JType* JType_GetType(JNIEnv* jenv, jclass classRef, jboolean resolve)
         }
 
         JType_AddClassAttribute(jenv, type);
+        JPy_DECREF(typeKey);
 
         //printf("T5: type->tp_init=%p\n", ((PyTypeObject*)type)->tp_init);
 
@@ -226,8 +227,12 @@ JPy_JType* JType_GetType(JNIEnv* jenv, jclass classRef, jboolean resolve)
             return NULL;
         }
     }
-    
-    JPy_INCREF(type);
+
+    // Only increment the refcount when the type is found in the registry to guarantee that we return a new reference
+    if (typeValue != NULL) {
+        JPy_INCREF(type);
+    }
+
     return type;
 }
 

--- a/src/main/c/jpy_module.c
+++ b/src/main/c/jpy_module.c
@@ -800,11 +800,7 @@ PyObject* JType_CreateJavaByteBufferObj(JNIEnv* jenv, PyObject* pyObj)
 
 PyObject* JPy_byte_buffer_internal(JNIEnv* jenv, PyObject* self, PyObject* args)
 {
-    jobject byteBufferRef;
     PyObject* pyObj;
-    PyObject* newPyObj;
-    Py_buffer *pyBuffer;
-    JPy_JByteBufferObj* byteBuffer;
 
     if (!PyArg_ParseTuple(args, "O:byte_buffer", &pyObj)) {
         return NULL;

--- a/src/test/java/org/jpy/fixtures/CyclicReferenceChild1.java
+++ b/src/test/java/org/jpy/fixtures/CyclicReferenceChild1.java
@@ -27,4 +27,11 @@ public class CyclicReferenceChild1 extends CyclicReferenceParent {
     public int get_x() {
         return this.x;
     }
+
+    public CyclicReferenceChild2[] getChild2s() {
+        CyclicReferenceChild2[] child2s = new CyclicReferenceChild2[2];
+        child2s[0] = new CyclicReferenceChild2();
+        child2s[1] = new CyclicReferenceChild2();
+        return child2s;
+    }
 }

--- a/src/test/java/org/jpy/fixtures/CyclicReferenceChild1.java
+++ b/src/test/java/org/jpy/fixtures/CyclicReferenceChild1.java
@@ -1,0 +1,30 @@
+//
+// Copyright 2024 jpy-consortium
+//
+
+package org.jpy.fixtures;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+
+/**
+ * Used as a test class for the test cases in jpy_gettype_test.py
+ *
+ * @author Jianfeng Mao
+ */
+@SuppressWarnings("UnusedDeclaration")
+public class CyclicReferenceChild1 extends CyclicReferenceParent {
+    private int x;
+
+    private CyclicReferenceChild1(int x) {
+        this.x = x;
+    }
+
+    public static CyclicReferenceChild1 of(int x) {
+        return new CyclicReferenceChild1(x);
+    }
+
+    public int get_x() {
+        return this.x;
+    }
+}

--- a/src/test/java/org/jpy/fixtures/CyclicReferenceChild2.java
+++ b/src/test/java/org/jpy/fixtures/CyclicReferenceChild2.java
@@ -14,4 +14,7 @@ import java.lang.reflect.Method;
  */
 @SuppressWarnings("UnusedDeclaration")
 public class CyclicReferenceChild2 extends CyclicReferenceParent {
+    public String getName() {
+        return "Child2: " + this.toString();
+    }
 }

--- a/src/test/java/org/jpy/fixtures/CyclicReferenceChild2.java
+++ b/src/test/java/org/jpy/fixtures/CyclicReferenceChild2.java
@@ -1,0 +1,17 @@
+//
+// Copyright 2024 jpy-consortium
+//
+
+package org.jpy.fixtures;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+
+/**
+ * Used as a test class for the test cases in jpy_gettype_test.py
+ *
+ * @author Jianfeng Mao
+ */
+@SuppressWarnings("UnusedDeclaration")
+public class CyclicReferenceChild2 extends CyclicReferenceParent {
+}

--- a/src/test/java/org/jpy/fixtures/CyclicReferenceGrandParent.java
+++ b/src/test/java/org/jpy/fixtures/CyclicReferenceGrandParent.java
@@ -1,0 +1,33 @@
+//
+// Copyright 2024 jpy-consortium
+//
+
+package org.jpy.fixtures;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+
+/**
+ * Used as a test class for the test cases in jpy_gettype_test.py
+ *
+ * @author Jianfeng Mao
+ */
+@SuppressWarnings("UnusedDeclaration")
+public class CyclicReferenceGrandParent {
+    private int x;
+    public int z = 100;
+
+    public CyclicReferenceGrandParent() {
+    }
+
+    public void refChild2(CyclicReferenceChild2 child2) {
+    }
+
+    public int grandParentMethod() {
+        return 888;
+    }
+
+    public int get_x() {
+        return this.x;
+    }
+}

--- a/src/test/java/org/jpy/fixtures/CyclicReferenceParent.java
+++ b/src/test/java/org/jpy/fixtures/CyclicReferenceParent.java
@@ -1,0 +1,32 @@
+//
+// Copyright 2024 jpy-consortium
+//
+
+package org.jpy.fixtures;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+
+/**
+ * Used as a test class for the test cases in jpy_gettype_test.py
+ *
+ * @author Jianfeng Mao
+ */
+@SuppressWarnings("UnusedDeclaration")
+public abstract class CyclicReferenceParent extends CyclicReferenceGrandParent {
+    private int x;
+    public int y = 10;
+
+    public static CyclicReferenceChild1 of(int x) {
+        return CyclicReferenceChild1.of(x);
+    }
+
+    public int parentMethod() {
+        return 88;
+    }
+
+    public int get_x() {
+        return this.x;
+    }
+
+}

--- a/src/test/java/org/jpy/fixtures/GetTypeFailureChild.java
+++ b/src/test/java/org/jpy/fixtures/GetTypeFailureChild.java
@@ -1,0 +1,26 @@
+//
+// Copyright 2024 jpy-consortium
+//
+
+package org.jpy.fixtures;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+
+/**
+ * Used as a test class for the test cases in jpy_gettype_test.py
+ *
+ * @author Jianfeng Mao
+ */
+@SuppressWarnings("UnusedDeclaration")
+public class GetTypeFailureChild extends GetTypeFailureParent {
+    private int x;
+
+    private GetTypeFailureChild(int x) {
+        this.x = x;
+    }
+
+    public static GetTypeFailureChild of(int x) {
+        return new GetTypeFailureChild(x);
+    }
+}

--- a/src/test/java/org/jpy/fixtures/GetTypeFailureParent.java
+++ b/src/test/java/org/jpy/fixtures/GetTypeFailureParent.java
@@ -1,0 +1,24 @@
+//
+// Copyright 2024 jpy-consortium
+//
+
+package org.jpy.fixtures;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+
+/**
+ * Used as a test class for the test cases in jpy_gettype_test.py
+ *
+ * @author Jianfeng Mao
+ */
+@SuppressWarnings("UnusedDeclaration")
+public abstract class GetTypeFailureParent {
+    static {
+        toFail();
+    }
+
+    static void toFail() {
+        throw new RuntimeException("Can't be loaded!");
+    }
+}

--- a/src/test/python/jpy_gettype_test.py
+++ b/src/test/python/jpy_gettype_test.py
@@ -87,6 +87,14 @@ class TestGetClass(unittest.TestCase):
         self.assertEqual(10, j_child1.y)
         self.assertEqual(100, j_child1.z)
 
+    def test_component_type_resolution(self):
+        j_child1_class = jpy.get_type("org.jpy.fixtures.CyclicReferenceChild1")
+        j_child1 = j_child1_class.of(8)
+        j_child2s = j_child1.getChild2s()
+        self.assertIn("[Lorg.jpy.fixtures.CyclicReferenceChild2;", repr(type(j_child2s)))
+        for j_child2 in j_child2s:
+            self.assertTrue(j_child2.getName().startswith("Child2"))
+
 
 if __name__ == '__main__':
     print('\nRunning ' + __file__)

--- a/src/test/python/jpy_gettype_test.py
+++ b/src/test/python/jpy_gettype_test.py
@@ -73,7 +73,7 @@ class TestGetClass(unittest.TestCase):
 
     def test_cyclic_reference(self):
         """
-        Test if delaying resolving super classes doesn't break existing class reference pattern.
+        Test if delaying resolving super classes breaks existing class reference pattern.
         """
         j_child1_class = jpy.get_type("org.jpy.fixtures.CyclicReferenceChild1")
         j_child2_class = jpy.get_type("org.jpy.fixtures.CyclicReferenceChild2")

--- a/src/test/python/jpy_gettype_test.py
+++ b/src/test/python/jpy_gettype_test.py
@@ -95,6 +95,11 @@ class TestGetClass(unittest.TestCase):
         for j_child2 in j_child2s:
             self.assertTrue(j_child2.getName().startswith("Child2"))
 
+    def test_fail_init_supertype(self):
+        with self.assertRaises(ValueError) as cm:
+            j_child_class = jpy.get_type("org.jpy.fixtures.GetTypeFailureChild")
+        print(str(cm.exception))
+
 
 if __name__ == '__main__':
     print('\nRunning ' + __file__)

--- a/src/test/python/jpy_gettype_test.py
+++ b/src/test/python/jpy_gettype_test.py
@@ -71,6 +71,21 @@ class TestGetClass(unittest.TestCase):
             for i in range(200):
                 jpy.get_type(java_type)
 
+    def test_cyclic_reference(self):
+        """
+        Test if delaying resolving super classes doesn't break existing class reference pattern.
+        """
+        j_child1_class = jpy.get_type("org.jpy.fixtures.CyclicReferenceChild1")
+        j_child2_class = jpy.get_type("org.jpy.fixtures.CyclicReferenceChild2")
+        j_child2 = j_child2_class()
+
+        j_child1 = j_child1_class.of(8)
+        self.assertEqual(88, j_child1.parentMethod())
+        self.assertEqual(888, j_child1.grandParentMethod())
+        self.assertIsNone(j_child1.refChild2(j_child2))
+        self.assertEqual(8, j_child1.get_x())
+        self.assertEqual(10, j_child1.y)
+        self.assertEqual(100, j_child1.z)
 
 
 if __name__ == '__main__':

--- a/src/test/python/jpy_gettype_test.py
+++ b/src/test/python/jpy_gettype_test.py
@@ -98,7 +98,6 @@ class TestGetClass(unittest.TestCase):
     def test_fail_init_supertype(self):
         with self.assertRaises(ValueError) as cm:
             j_child_class = jpy.get_type("org.jpy.fixtures.GetTypeFailureChild")
-        print(str(cm.exception))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #142

1. be able to generate Python types from Java classes with complicated cyclic references
2. fix a reference counting issue when a new Python type fails to finalize
3. fix the Python tests and disable the Java tests due to previous changes (years ago) to enable auto PyObjects cleanup in Java.
4. add a limited GH check workflow to run the Python tests on Linux
5. add two new Python test cases