### PR TITLE
Remove pip upgrade from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,7 @@ jobs:
           distribution: 'temurin'
           java-version: '8'
 
+      - run: pip install setuptools
       - run: ${{ matrix.info.cmd }}
 
       - uses: actions/upload-artifact@v4
@@ -121,6 +122,8 @@ jobs:
           distribution: 'temurin'
           java-version: '8'
 
+      - run: pip install --upgrade pip
+      - run: pip install --upgrade setuptools
       - run: ${{ matrix.info.cmd }}
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,8 +76,6 @@ jobs:
           distribution: 'temurin'
           java-version: '8'
 
-      - run: pip install --upgrade pip
-      - run: pip install --upgrade setuptools
       - run: ${{ matrix.info.cmd }}
 
       - uses: actions/upload-artifact@v4
@@ -123,8 +121,6 @@ jobs:
           distribution: 'temurin'
           java-version: '8'
 
-      - run: pip install --upgrade pip
-      - run: pip install --upgrade setuptools
       - run: ${{ matrix.info.cmd }}
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,7 +25,5 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
-      - run: pip install --upgrade setuptools
-
       - name: Run Test
         run: python setup.py test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,5 +25,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
+      - run: pip install setuptools
+
       - name: Run Test
         run: python setup.py test


### PR DESCRIPTION
In certain environments, pip fails when it is invoked directly; it requires running it via the `python -m pip`.

```
2024-07-01T15:36:28.7531716Z ##[group]Run pip install --upgrade pip
2024-07-01T15:36:28.7532786Z ␛[36;1mpip install --upgrade pip␛[0m
2024-07-01T15:36:28.7657862Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
2024-07-01T15:36:28.7658373Z env:
2024-07-01T15:36:28.7658824Z   pythonLocation: C:\hostedtoolcache\windows\Python\3.8.10\x64
2024-07-01T15:36:28.7659493Z   PKG_CONFIG_PATH: C:\hostedtoolcache\windows\Python\3.8.10\x64/lib/pkgconfig
2024-07-01T15:36:28.7660136Z   Python_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.8.10\x64
2024-07-01T15:36:28.7660710Z   Python2_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.8.10\x64
2024-07-01T15:36:28.7661290Z   Python3_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.8.10\x64
2024-07-01T15:36:28.7661929Z   JAVA_HOME: C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\8.0.412-8\x64
2024-07-01T15:36:28.7662624Z   JAVA_HOME_8_X64: C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\8.0.412-8\x64
2024-07-01T15:36:28.7663174Z ##[endgroup]
2024-07-01T15:36:38.7384905Z Requirement already satisfied: pip in c:\hostedtoolcache\windows\python\3.8.10\x64\lib\site-packages (24.1)
2024-07-01T15:36:39.0876540Z Collecting pip
2024-07-01T15:36:39.1091359Z   Downloading pip-24.1.1-py3-none-any.whl.metadata (3.6 kB)
2024-07-01T15:36:39.1792167Z Downloading pip-24.1.1-py3-none-any.whl (1.8 MB)
2024-07-01T15:36:39.2204216Z    ---------------------------------------- 1.8/1.8 MB 58.5 MB/s eta 0:00:00
2024-07-01T15:36:39.3613861Z ERROR: To modify pip, please run the following command:
2024-07-01T15:36:39.3615157Z c:\hostedtoolcache\windows\python\3.8.10\x64\python.exe -m pip install --upgrade pip
2024-07-01T15:36:39.4510941Z
2024-07-01T15:36:39.4512808Z [notice] A new release of pip is available: 24.1 -> 24.1.1
2024-07-01T15:36:39.4514062Z [notice] To update, run: python.exe -m pip install --upgrade pip
2024-07-01T15:36:39.9822011Z ##[error]Process completed with exit code 1.
```

While we could update the CI to plumb it through `python -m pip`, we can likely achieve better reproducibility and determinism by using the version of pip that is already installed.