### PR TITLE
fix: Make org.jpy.PyLib.getCurrentLocals/Globals work for Python 3.13

### DIFF
--- a/src/main/c/jni/org_jpy_PyLib.c
+++ b/src/main/c/jni/org_jpy_PyLib.c
@@ -559,7 +559,7 @@ JNIEXPORT jobject JNICALL Java_org_jpy_PyLib_getCurrentGlobals
 
 #if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION <= 12
     globals = PyEval_GetGlobals(); // borrowed ref
-    JPy_INCREF(globals);
+    JPy_XINCREF(globals);
 #else
     // See https://peps.python.org/pep-0667 for the change in Python 3.13
     globals = PyEval_GetFrameGlobals(); // new ref
@@ -590,7 +590,7 @@ JNIEXPORT jobject JNICALL Java_org_jpy_PyLib_getCurrentLocals
 
 #if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION <= 12
     locals = PyEval_GetLocals(); // borrowed ref
-    JPy_INCREF(locals);
+    JPy_XINCREF(locals);
 #else
     // See https://peps.python.org/pep-0667 for the change in Python 3.13
     locals = PyEval_GetFrameLocals(); // new ref

--- a/src/main/c/jni/org_jpy_PyLib.c
+++ b/src/main/c/jni/org_jpy_PyLib.c
@@ -521,6 +521,7 @@ PyObject *getMainGlobals() {
     }
 
     pyGlobals = PyModule_GetDict(pyMainModule); // borrowed ref
+    JPy_INCREF(pyGlobals);
 
     return pyGlobals;
 }
@@ -532,7 +533,7 @@ JNIEXPORT jobject JNICALL Java_org_jpy_PyLib_getMainGlobals
 
     JPy_BEGIN_GIL_STATE
 
-    globals = getMainGlobals(); // borrowed ref
+    globals = getMainGlobals(); // new ref
     if (globals == NULL) {
         goto error;
     }
@@ -543,6 +544,7 @@ JNIEXPORT jobject JNICALL Java_org_jpy_PyLib_getMainGlobals
     }
 
 error:
+    JPy_XDECREF(globals);
     JPy_END_GIL_STATE
 
     return objectRef;
@@ -555,10 +557,12 @@ JNIEXPORT jobject JNICALL Java_org_jpy_PyLib_getCurrentGlobals
 
     JPy_BEGIN_GIL_STATE
 
-#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION > 12
-    globals = PyEval_GetFrameGlobals(); // new ref
-#else
+#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION <= 12
     globals = PyEval_GetGlobals(); // borrowed ref
+    JPy_INCREF(globals);
+#else
+    // See https://peps.python.org/pep-0667 for the change in Python 3.13
+    globals = PyEval_GetFrameGlobals(); // new ref
 #endif
 
     if (globals == NULL) {
@@ -571,11 +575,9 @@ JNIEXPORT jobject JNICALL Java_org_jpy_PyLib_getCurrentGlobals
     }
 
 error:
-#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION > 12
     JPy_XDECREF(globals);
-#endif
-
     JPy_END_GIL_STATE
+
     return objectRef;
 }
 
@@ -586,10 +588,12 @@ JNIEXPORT jobject JNICALL Java_org_jpy_PyLib_getCurrentLocals
 
     JPy_BEGIN_GIL_STATE
 
-#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION > 12
-        locals = PyEval_GetFrameLocals(); // new ref
+#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION <= 12
+    locals = PyEval_GetLocals(); // borrowed ref
+    JPy_INCREF(locals);
 #else
-        locals = PyEval_GetLocals(); // borrowed ref
+    // See https://peps.python.org/pep-0667 for the change in Python 3.13
+    locals = PyEval_GetFrameLocals(); // new ref
 #endif
 
     if (locals == NULL) {
@@ -602,11 +606,9 @@ JNIEXPORT jobject JNICALL Java_org_jpy_PyLib_getCurrentLocals
     }
 
 error:
-#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION > 12
     JPy_XDECREF(locals);
-#endif
-
     JPy_END_GIL_STATE
+
     return objectRef;
 }
 
@@ -919,7 +921,8 @@ jlong executeInternal(JNIEnv* jenv, jclass jLibClass, jint jStart, jobject jGlob
 
     if (jGlobals == NULL) {
         JPy_DIAG_PRINT(JPy_DIAG_F_EXEC, "Java_org_jpy_PyLib_executeInternal: using main globals\n");
-        pyGlobals = getMainGlobals();
+        pyGlobals = getMainGlobals(); // new ref
+        decGlobals = JNI_TRUE;
         if (pyGlobals == NULL) {
             PyLib_HandlePythonException(jenv);
             goto error;

--- a/src/main/c/jni/org_jpy_PyLib.c
+++ b/src/main/c/jni/org_jpy_PyLib.c
@@ -555,7 +555,11 @@ JNIEXPORT jobject JNICALL Java_org_jpy_PyLib_getCurrentGlobals
 
     JPy_BEGIN_GIL_STATE
 
+#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION > 12
+    globals = PyEval_GetFrameGlobals(); // new ref
+#else
     globals = PyEval_GetGlobals(); // borrowed ref
+#endif
 
     if (globals == NULL) {
         goto error;
@@ -567,8 +571,11 @@ JNIEXPORT jobject JNICALL Java_org_jpy_PyLib_getCurrentGlobals
     }
 
 error:
-    JPy_END_GIL_STATE
+#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION > 12
+    JPy_XDECREF(globals);
+#endif
 
+    JPy_END_GIL_STATE
     return objectRef;
 }
 
@@ -579,7 +586,12 @@ JNIEXPORT jobject JNICALL Java_org_jpy_PyLib_getCurrentLocals
 
     JPy_BEGIN_GIL_STATE
 
-    locals = PyEval_GetLocals(); // borrowed ref
+#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION > 12
+        locals = PyEval_GetFrameLocals(); // new ref
+#else
+        locals = PyEval_GetLocals(); // borrowed ref
+#endif
+
     if (locals == NULL) {
         goto error;
     }
@@ -590,8 +602,11 @@ JNIEXPORT jobject JNICALL Java_org_jpy_PyLib_getCurrentLocals
     }
 
 error:
-    JPy_END_GIL_STATE
+#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION > 12
+    JPy_XDECREF(locals);
+#endif
 
+    JPy_END_GIL_STATE
     return objectRef;
 }
 

--- a/src/main/c/jpy_module.h
+++ b/src/main/c/jpy_module.h
@@ -33,6 +33,7 @@ extern "C" {
 #if 1
 #define JPy_DECREF(x) Py_DECREF(x)
 #define JPy_INCREF(x) Py_INCREF(x)
+#define JPy_XINCREF(x) Py_XINCREF(x)
 #define JPy_XDECREF(x) Py_XDECREF(x)
 #else
 #include "jpy_diag.h"


### PR DESCRIPTION
Python 3.13.0rc1 includes PEP667 (https://peps.python.org/pep-0667) and it made PyEval_GetLocals() no longer behave the same way as in Python 3.12 and older, which could be a bug to report to the cpython team but probably not worth it as it is marked as deprecated  together with PyEval_GetGlobals().  