### PR TITLE
Improve libpython search with python's sysconfig INSTSONAME

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # jpy Changelog
 
 ## Version 1.1.0 (in development)
+* [#179](https://github.com/jpy-consortium/jpy/pull/179) Improve libpython search with python's sysconfig INSTSONAME
 
 ## Version 1.0.0
 * [#176](https://github.com/jpy-consortium/jpy/pull/176) fix:  make PyObject cleanup thread-safe in free-threaded Python and reduce contention

--- a/jpyutil.py
+++ b/jpyutil.py
@@ -329,6 +329,9 @@ def _find_python_dll_file(fail=False):
     logger.debug("Potential Python shared library search dirs: %s" % repr(search_dirs))
 
     # Prepare list of possible library file names
+    # Prefer "Install .so name" as first candidate for file_names
+    instsoname = sysconfig.get_config_var("INSTSONAME")
+    file_names = [ instsoname ] if instsoname else []
 
     # account for Python debug builds
 
@@ -346,14 +349,14 @@ def _find_python_dll_file(fail=False):
 
     if platform.system() == 'Windows':
         versions = (vmaj + vmin, vmaj, vmaj + vmin + dll_suffix, '')
-        file_names = ['python' + v + '.dll' for v in versions]
+        file_names += ['python' + v + '.dll' for v in versions]
     elif platform.system() == 'Darwin':
         versions = (vmaj + "." + vmin, vmaj, vmaj + "." + vmin + dll_suffix, '')
-        file_names = ['libpython' + v + '.dylib' for v in versions] + \
-                     ['libpython' + v + '.so' for v in versions]
+        file_names += ['libpython' + v + '.dylib' for v in versions]
+        file_names += ['libpython' + v + '.so' for v in versions]
     else:
         versions = (vmaj + "." + vmin, vmaj, vmaj + "." + vmin + dll_suffix, '')
-        file_names = ['libpython' + v + '.so' for v in versions]
+        file_names += ['libpython' + v + '.so' for v in versions]
 
     logger.debug("Potential Python shared library file names: %s" % repr(file_names))
 


### PR DESCRIPTION
This should be considered a partial improvement related to #75.

A fuller solution might involve listing which shared objects were actually loaded via [`dl_iterate_phdr`](https://man7.org/linux/man-pages/man3/dl_iterate_phdr.3.html).

https://github.com/python/cpython/issues/119349