### PR TITLE
Fix bake-action build step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,6 +145,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - run: mkdir /tmp/dist
+
       - name: Bake
         uses: docker/bake-action@v4.6.0
         with:


### PR DESCRIPTION
It is currently failing with

```
buildx bake failed with: ERROR: failed to evaluate path "/tmp/dist": lstat /tmp/dist: no such file or directory
```

Likely, a newer version of buildx does not create the directory if it does not exist, or something like that.

It appears this is fixed in buildx 0.19.3 with https://github.com/docker/buildx/pull/2860, but the CI runners are shipping with 0.19.2; we _could_ pin the version of buildx, but creating the directory seems saner for now.