### PR TITLE
Update docker/bake action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,9 @@ jobs:
       - run: mkdir /tmp/dist
 
       - name: Bake
-        uses: docker/bake-action@v4.6.0
+        uses: docker/bake-action@v5.11.0
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           files: .github/docker/docker-bake.hcl
           pull: true


### PR DESCRIPTION
The collect-artifacts job in the actions/download-artifact step is failing if we don't disable the bake action's artifact uploading. It may due to the use of non-standard characters in the file name; for example `jpy-consortium~jpy~CN2MCZ+7.dockerbuild`, which seems to cause an error "Unable to download artifact(s): Unable to download and extract artifact: Artifact download failed after 5 retries"

See https://github.com/docker/bake-action/tree/v5.11.0?tab=readme-ov-file#environment-variables