### PR TITLE
chore: Replace Java 23 with 25 in Check CI due to EOL

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
-        java: ['11', '17', '21', '23']
+        java: ['11', '17', '21', '25']
     steps:
       - uses: actions/checkout@v6
 
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.13t', '3.14t']
-        java: ['11', '17', '21', '23']
+        java: ['11', '17', '21', '25']
     steps:
         - uses: actions/checkout@v6
 


### PR DESCRIPTION
Fixes #227

Note:
When JPY is used with Java 25, the following warning is raised during initialization.
```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::loadLibrary has been called by org.jpy.DL in an unnamed module (file:/Users/jianfengmao/git/jpy/target/classes/)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```

Besides the --enable-native-access flag, the following options was explored to suppress the warning silently:
1. modularize org.jpy package and automatically 
2. add the flag in `init_jvm' in jpyutil.py for Java >11

However, they are not skipped since they don't solve the issue in the real world due to 
1. JPMS isn't widely adopted at all, modularization would create more problems.
2. add the flag in init_jvm only works in python->java direction,  we might as well require users to be explicit about the behavior.


