### PR TITLE
fix: fix the jpy_cleanup_thread_test for 3.14t

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -16,11 +16,12 @@ RUN \
     echo "deb [signed-by=/usr/share/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list; \
     apt-get -qq update; \
     for i in 1 2 3 4 5; do \
-        apt-get -qq -y --no-install-recommends --fix-missing install temurin-11-jdk maven && break; \
+        apt-get -qq -y --no-install-recommends install temurin-11-jdk maven && break; \
         echo "apt-get install attempt $i failed; retrying in 5s..."; \
         sleep 5; \
         apt-get -qq update || true; \
-    done
+    done; \
+    command -v mvn >/dev/null && command -v javac >/dev/null
 RUN \
     --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     set -eux; \

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -12,16 +12,15 @@ RUN \
     set -eux; \
     rm -f /etc/apt/apt.conf.d/docker-clean; \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' | tee /etc/apt/apt.conf.d/keep-cache; \
-    wget --no-hsts -O /usr/share/keyrings/adoptium.asc https://packages.adoptium.net/artifactory/api/gpg/key/public; \
+    echo 'Acquire::Retries "3";'           >  /etc/apt/apt.conf.d/80-retries; \
+    echo 'Acquire::Retries::Delay "true";'  >> /etc/apt/apt.conf.d/80-retries; \
+    echo 'Acquire::http::Timeout "30";'     >> /etc/apt/apt.conf.d/80-retries; \
+    echo 'Acquire::https::Timeout "30";'    >> /etc/apt/apt.conf.d/80-retries; \
+    wget --no-hsts --tries=3 --waitretry=5 --retry-connrefused --timeout=10 \
+         -O /usr/share/keyrings/adoptium.asc https://packages.adoptium.net/artifactory/api/gpg/key/public; \
     echo "deb [signed-by=/usr/share/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list; \
     apt-get -qq update; \
-    for i in 1 2 3 4 5; do \
-        apt-get -qq -y --no-install-recommends install temurin-11-jdk maven && break; \
-        echo "apt-get install attempt $i failed; retrying in 5s..."; \
-        sleep 5; \
-        apt-get -qq update || true; \
-    done; \
-    command -v mvn >/dev/null && command -v javac >/dev/null
+    apt-get -qq -y --no-install-recommends install temurin-11-jdk maven
 RUN \
     --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     set -eux; \

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -15,7 +15,12 @@ RUN \
     wget --no-hsts -O /usr/share/keyrings/adoptium.asc https://packages.adoptium.net/artifactory/api/gpg/key/public; \
     echo "deb [signed-by=/usr/share/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list; \
     apt-get -qq update; \
-    apt-get -qq -y --no-install-recommends install temurin-11-jdk maven
+    for i in 1 2 3 4 5; do \
+        apt-get -qq -y --no-install-recommends --fix-missing install temurin-11-jdk maven && break; \
+        echo "apt-get install attempt $i failed; retrying in 5s..."; \
+        sleep 5; \
+        apt-get -qq update || true; \
+    done
 RUN \
     --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     set -eux; \

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,6 @@
                     <destDir>java-apidocs</destDir>
                     <doctitle>${project.name} ${project.version} Java API</doctitle>
                     <windowtitle>${project.name} ${project.version} Java API</windowtitle>
-                    <excludePackageNames>org.jpy.annotations</excludePackageNames>
                     <encoding>UTF-8</encoding>
                     <maxmemory>256m</maxmemory>
                     <quiet>false</quiet>
@@ -129,14 +128,6 @@
                 </configuration>
             </plugin>
         </plugins>
-
-        <extensions>
-            <extension>
-                <groupId>org.apache.maven.wagon</groupId>
-                <artifactId>wagon-ssh</artifactId>
-                <version>1.0-beta-7</version>
-            </extension>
-        </extensions>
     </build>
 
     <profiles>

--- a/src/test/python/jpy_cleanup_thread_test.py
+++ b/src/test/python/jpy_cleanup_thread_test.py
@@ -55,25 +55,28 @@ FLOOD   = 20_000
 TIMEOUT = 10.0   # seconds: generous upper bound for daemon to drain FLOOD objects
 
 # ── Destruction tracking ──────────────────────────────────────────────────────
-# Counters must work on both GIL-enabled and free-threaded CPython, including
-# from inside Trackable.__del__.
+# Counters must be safe to update from Trackable.__del__ on both GIL and
+# free-threaded CPython.
 #
-# We use lists with append(None) / len() instead of an integer + lock or
-# itertools.count():
-#   * GIL Python — list.append() is a single C call that runs to completion
-#     under the GIL, so it is atomic even when two threads append concurrently
-#     (see test_06, where the cleanup daemon and the main thread both fire
-#     __del__).  len(list) is also a single C call → atomic.
-#   * Free-threaded Python — list.append() takes the list's per-object critical
-#     section.  That lock is only a safe point on contention; the cleanup
-#     daemon defers Py_DECREF back to the owning thread, so each counter has a
-#     single writer in steady state and the critical section stays on its
-#     uncontested fast path.  Acquiring a Python-level lock (threading.Lock /
-#     RLock) inside __del__ would be a safe point and could drain queued
-#     decrefs recursively — see doc/freethreaded-safe-points.md.
+# A "safe point" is a place where the interpreter may pause a thread to run
+# bookkeeping — signals, scheduled callbacks, GC, and (on free-threaded
+# builds) draining queued cross-thread Py_DECREFs. Threads reach safe points
+# at the eval-breaker check on CALL/RETURN/JUMP_BACKWARD bytecodes and
+# whenever a primitive blocks (a contended Python-level lock, a thread-state
+# detach for a blocking call). Guarding an incrementing counter with a lock
+# inside __del__ can therefore drain queued decrefs while the lock is being
+# acquired, calling more __del__s recursively and causing RecursionError.
 #
-# When CPython gh-124366 lands a thread-safe atomic counter in the threading
-# module, this idiom can be replaced with that API.
+# We therefore need a counter that is atomic without taking any
+# Python-level lock. list.append(None) / len() satisfies both:
+#   * GIL Python — both are single C calls under the GIL → atomic.
+#   * Free-threaded — list.append() uses the list's per-object critical
+#     section, which is a safe point only on contention. The cleanup daemon
+#     defers Py_DECREF back to the owning thread, so each counter has a
+#     single writer and the critical section stays uncontested.
+#
+# When CPython gh-124366 lands a thread-safe atomic counter, this idiom can
+# be replaced with that API.
 
 _created   = []
 _destroyed = []

--- a/src/test/python/jpy_cleanup_thread_test.py
+++ b/src/test/python/jpy_cleanup_thread_test.py
@@ -55,23 +55,25 @@ FLOOD   = 20_000
 TIMEOUT = 10.0   # seconds: generous upper bound for daemon to drain FLOOD objects
 
 # ── Destruction tracking ──────────────────────────────────────────────────────
-# Counters must work on both GIL-enabled CPython and freethreaded CPython 3.14t.
+# Counters must work on both GIL-enabled and free-threaded CPython, including
+# from inside Trackable.__del__.
 #
-# Why a lock is *not* used:
-#   On freethreaded 3.14t, acquiring any Python-level lock inside __del__ is a
-#   safe point. That lets the interpreter drain pending deferred decrefs, which
-#   fires more __del__ calls, which re-acquire the same lock — leading to
-#   RecursionError. The cleanup daemon avoids this by deferring Py_DECREF back
-#   to the owning thread, so __del__ runs single-threaded per counter.
+# We use lists with append(None) / len() instead of an integer + lock or
+# itertools.count():
+#   * GIL Python — list.append() is a single C call that runs to completion
+#     under the GIL, so it is atomic even when two threads append concurrently
+#     (see test_06, where the cleanup daemon and the main thread both fire
+#     __del__).  len(list) is also a single C call → atomic.
+#   * Free-threaded Python — list.append() takes the list's per-object critical
+#     section.  That lock is only a safe point on contention; the cleanup
+#     daemon defers Py_DECREF back to the owning thread, so each counter has a
+#     single writer in steady state and the critical section stays on its
+#     uncontested fast path.  Acquiring a Python-level lock (threading.Lock /
+#     RLock) inside __del__ would be a safe point and could drain queued
+#     decrefs recursively — see doc/freethreaded-safe-points.md.
 #
-# Why ``list.append`` + ``len`` works on both:
-#   * GIL Python: list.append is a single C call that holds the GIL for its
-#     full duration → atomic even with two concurrent writers (test 06).
-#     len(list) reads ob_size in one C call → atomic.
-#   * Freethreaded 3.14t: list.append uses the list's per-object critical
-#     section. It's only a safe point on contention; deferred-decref keeps
-#     __init__ and __del__ single-writer per counter, so the lock is
-#     uncontested → no safe point in __del__ → no recursion cascade.
+# When CPython gh-124366 lands a thread-safe atomic counter in the threading
+# module, this idiom can be replaced with that API.
 
 _created   = []
 _destroyed = []

--- a/src/test/python/jpy_cleanup_thread_test.py
+++ b/src/test/python/jpy_cleanup_thread_test.py
@@ -55,24 +55,36 @@ FLOOD   = 20_000
 TIMEOUT = 10.0   # seconds: generous upper bound for daemon to drain FLOOD objects
 
 # ── Destruction tracking ──────────────────────────────────────────────────────
+# Counters must work on both GIL-enabled CPython and freethreaded CPython 3.14t.
+#
+# Why a lock is *not* used:
+#   On freethreaded 3.14t, acquiring any Python-level lock inside __del__ is a
+#   safe point. That lets the interpreter drain pending deferred decrefs, which
+#   fires more __del__ calls, which re-acquire the same lock — leading to
+#   RecursionError. The cleanup daemon avoids this by deferring Py_DECREF back
+#   to the owning thread, so __del__ runs single-threaded per counter.
+#
+# Why ``list.append`` + ``len`` works on both:
+#   * GIL Python: list.append is a single C call that holds the GIL for its
+#     full duration → atomic even with two concurrent writers (test 06).
+#     len(list) reads ob_size in one C call → atomic.
+#   * Freethreaded 3.14t: list.append uses the list's per-object critical
+#     section. It's only a safe point on contention; deferred-decref keeps
+#     __init__ and __del__ single-writer per counter, so the lock is
+#     uncontested → no safe point in __del__ → no recursion cascade.
 
-_lock      = threading.RLock()
-_created   = 0
-_destroyed = 0
+_created   = []
+_destroyed = []
 
 
 class Trackable:
     """Python object that counts constructions and destructions thread-safely."""
 
     def __init__(self):
-        global _created
-        with _lock:
-            _created += 1
+        _created.append(None)
 
     def __del__(self):
-        global _destroyed
-        with _lock:
-            _destroyed += 1
+        _destroyed.append(None)
 
 
 def _make_trackable():
@@ -80,15 +92,12 @@ def _make_trackable():
 
 
 def _reset():
-    global _created, _destroyed
-    with _lock:
-        _created = 0
-        _destroyed = 0
+    _created.clear()
+    _destroyed.clear()
 
 
 def _counts():
-    with _lock:
-        return _created, _destroyed
+    return len(_created), len(_destroyed)
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -326,4 +335,5 @@ class TestCleanupThreadStress(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    print('\nRunning ' + __file__)
     unittest.main()


### PR DESCRIPTION
1. the fix to the test solves a 'recursion depth limit exceeded' error in the test itself due to the use of lock and its being used as a safe point to deallocate refcount=zero object in 3.14t
2. due to some unknown networking hiccups in GH Actions, the CI run regularly fails when downloading external deps. The added retry-logic and the removal of unused deps in pom.xml should make the run more stable.